### PR TITLE
Fix for libxkbswitch.so.2

### DIFF
--- a/lua/xkbswitch.lua
+++ b/lua/xkbswitch.lua
@@ -23,7 +23,7 @@ else
         -- xkb-switch
         local all_libs_locations = vim.fn.systemlist('ldd $(which xkb-switch)')
         for _, value in ipairs(all_libs_locations) do
-            if string.find(value, 'libxkbswitch.so.1') then
+            if string.find(value, 'libxkbswitch.so.1') or string.find(value, 'libxkbswitch.so.2') then
                 if string.find(value, 'not found') then
                     xkb_switch_lib = nil
                 else


### PR DESCRIPTION
Recently I found that xkbswitch.nvim stopped working because xkb-switch-i3 had switched to own versioning scheme. The plugin falls with error at startup because it can't find libxkbswitch.so.2, so I fixed this behavior and the plugin continued to work.