### PR TITLE
feat: allow to customize events for get focus autocommand

### DIFF
--- a/lua/xkbswitch.lua
+++ b/lua/xkbswitch.lua
@@ -1,4 +1,8 @@
 local M = {}
+
+-- Default parameters
+M.events_get_focus = {'FocusGained', 'CmdlineLeave'}
+
 -- nvim_create_autocmd shortcut
 local autocmd = vim.api.nvim_create_autocmd
 
@@ -64,7 +68,14 @@ if user_us_layout_variation == nil then
         "(xkbswitch.lua) Error occured: could not find the English layout. Check your layout list. (xkb-switch -l / issw -l / g3kb-switch -l)")
 end
 
-function M.setup()
+function M.setup(opts)
+
+    -- Parse provided options
+    opts = opts or {}
+    if opts.events_get_focus then
+        M.events_get_focus = opts.events_get_focus
+    end
+
     -- When leaving Insert Mode:
     -- 1. Save the current layout
     -- 2. Switch to the US layout
@@ -85,7 +96,7 @@ function M.setup()
     -- 1. Save the current layout
     -- 2. Switch to the US layout if Normal Mode or Visual Mode is the current mode
     autocmd(
-        {'FocusGained', 'CmdlineLeave'},
+        M.events_get_focus,
         {
             pattern = "*",
             callback = function()


### PR DESCRIPTION
I've encountered the following behaviour:
1. Go to insert mode and switch to a non-EN layout (this becomes new saved layout)
2. Go back to normal (layout switches to EN), and then to command mode 
3. Exit command mode and enter insert mode

Here one might expect the layout to switch back to non-EN (saved layout), however it stays EN. The reason is that when exiting command mode, saved layout gets changed to EN.

In order to allow both for the current behaviour and for the alternative behaviour describe above, I suggest to introduce optional config parameter `events_get_focus` with the list of events for the relevant autocommand. For example, the above alternative behaviour can be achieved by passing
```
events_get_focus = { "FocusGained" }
```
to the `require("xkbswitch").setup()` function.
Default behaviour (when no parameters are passed) does not change.

